### PR TITLE
Add option to use systemrdl name property in sidebar

### DIFF
--- a/src/peakrdl_html/exporter.py
+++ b/src/peakrdl_html/exporter.py
@@ -51,6 +51,8 @@ class HTMLExporter:
             table in the node's description.
             Use this to bring forward user-defined properties, or other built-in
             properties in your documentation.
+        rdl_name_in_sidebar: bool
+            Use systemRDL name property in sidebar instead of instance name (if available). Default is False
         """
         self.output_dir = "" # type: str
         self.RALData = [] # type: List[Dict[str, Any]]
@@ -70,6 +72,7 @@ class HTMLExporter:
         self.generate_source_links = kwargs.pop("generate_source_links", True)
         gmtu_translators = kwargs.pop("gitmetheurl_translators", None)
         user_template_dir = kwargs.pop("user_template_dir", None)
+        self.rdl_name_in_sidebar = kwargs.pop("rdl_name_in_sidebar", False)
 
         # Check for stray kwargs
         if kwargs:
@@ -196,10 +199,17 @@ class HTMLExporter:
 
         self.indexer.add_node(node, this_id)
 
+        # Set display name based on user input and presence of name property
+        if self.rdl_name_in_sidebar:
+            display_name = node.get_property('name', default=node.inst.inst_name)
+        else:
+            display_name = node.inst.inst_name
+    
         ral_entry = {
             'parent'    : parent_id,
             'children'  : child_ids,
             'name'      : node.inst.inst_name,
+            'display'   : display_name,
             'offset'    : BigInt(node.inst.addr_offset),
             'size'      : BigInt(node.size),
         }

--- a/src/peakrdl_html/static/js/sidebar.js
+++ b/src/peakrdl_html/static/js/sidebar.js
@@ -145,13 +145,13 @@ class Sidebar {
         link.className = "node-link";
         link.onclick = onClickTreeLink;
         if(RAL.is_array(id)){
-            var txt = node.name;
+            var txt = node.display;
             for(var i=0; i<node.dims.length; i++) {
                 txt += "[]";
             }
             link.innerHTML = txt;
         } else {
-            link.innerHTML = node.name;
+            link.innerHTML = node.display;
         }
         div.appendChild(link);
 


### PR DESCRIPTION
When rdl_name_in_sidebar=True, the sidebar will display nodes by their name property, if set, or instance name. When set False, which is the default, the old behaviour of always using the instance name is used. Navigation and breadcrumbs still use only the instance name