### PR TITLE
Add generate_source_links to cfg_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,5 @@ additional things can be configured via the TOML configuration file.
 user_template_dir = "path/to/dir/"
 user_static_dir = "path/to/dir/"
 extra_doc_properties = ["list", "of", "properties"]
+generate_source_links = false
 ```

--- a/src/peakrdl_html/__peakrdl__.py
+++ b/src/peakrdl_html/__peakrdl__.py
@@ -18,6 +18,7 @@ class Exporter(ExporterSubcommandPlugin):
         "user_template_dir": schema.DirectoryPath(),
         "user_static_dir": schema.DirectoryPath(),
         "extra_doc_properties": [schema.String()],
+        "generate_source_links": schema.Boolean(),
     }
 
 
@@ -52,6 +53,7 @@ class Exporter(ExporterSubcommandPlugin):
             user_template_dir=self.cfg['user_template_dir'],
             user_static_dir=self.cfg['user_static_dir'],
             extra_doc_properties=self.cfg['extra_doc_properties'],
+            generate_source_links=self.cfg['generate_source_links'],
         )
         html.export(
             top_node,


### PR DESCRIPTION
This PR adds the option to add `generate_source_links` to the `cfg_schema` of PeakRDL. Currently, the `generate_source_links` option cannot be set, if PeakRDL-html is invoked from the PeakRDL command line tool. For this reason, a password needs to be entered every time the HTML documentation shall be generated, if the used ssh-key is password protected and not loaded by default. This condition makes it quite hard to embed this invocation into another script.