### PR TITLE
Add support for signed/fixed-point fields

### DIFF
--- a/src/peakrdl_html/__peakrdl__.py
+++ b/src/peakrdl_html/__peakrdl__.py
@@ -4,6 +4,7 @@ from peakrdl.plugins.exporter import ExporterSubcommandPlugin
 from peakrdl.config import schema
 
 from .exporter import HTMLExporter
+from .udps import ALL_UDPS
 
 if TYPE_CHECKING:
     import argparse
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
 class Exporter(ExporterSubcommandPlugin):
     short_desc = "Generate HTML documentation"
     long_desc = "Generate dynamic HTML documentation pages"
+
+    udp_definitions = ALL_UDPS
 
     cfg_schema = {
         "user_template_dir": schema.DirectoryPath(),

--- a/src/peakrdl_html/exporter.py
+++ b/src/peakrdl_html/exporter.py
@@ -220,18 +220,29 @@ class HTMLExporter:
                     # support this, so stuff a 0 in its place
                     field_reset = 0
 
+                is_signed = field.get_property("is_signed")
+
                 ral_field = {
-                    'name' : field.inst.inst_name,
-                    'lsb'  : field.inst.lsb,
-                    'msb'  : field.inst.msb,
-                    'reset': BigInt(field_reset),
-                    'disp' : 'H'
+                    'name'     : field.inst.inst_name,
+                    'lsb'      : field.inst.lsb,
+                    'msb'      : field.inst.msb,
+                    'reset'    : BigInt(field_reset),
+                    'is_signed': is_signed,
+                    'disp'     : 'H',
                 }
 
                 field_enum = field.get_property("encode")
                 if field_enum is not None:
                     ral_field['encode'] = True
                     ral_field['disp'] = 'E'
+
+                if is_signed:
+                    ral_field['disp'] = 'D'
+
+                fracwidth = field.get_property("fracwidth")
+                if fracwidth is not None:
+                    ral_field['fracwidth'] = fracwidth
+                    ral_field['disp'] = 'R'
 
                 ral_fields.append(ral_field)
 

--- a/src/peakrdl_html/static/js/field_testers.js
+++ b/src/peakrdl_html/static/js/field_testers.js
@@ -76,7 +76,16 @@ function update_reg_value_tester(){
         var msb = BigInt(node.fields[i].msb);
         var lsb = BigInt(node.fields[i].lsb);
         var el = document.getElementById("_FieldValueTester" + node.fields[i].name);
-        var value = BigInt(el.value);
+        var value;
+        try {
+            value = parse_field_value(i, el.value);
+        } catch(error) {
+            if(error instanceof RangeError) {
+                value = error.clamped;
+            } else {
+                throw error;
+            }
+        }
         var mask = (1n << (msb - lsb + 1n)) - 1n;
         value = value & mask;
         reg_value = reg_value + (value << lsb);
@@ -107,11 +116,97 @@ function update_field_value_tester(idx){
     }
 }
 
+// Helper: Convert raw unsigned value to signed integer
+function toSigned(value, width) {
+    var sign_bit = 1n << (BigInt(width) - 1n);
+    if((value & sign_bit) !== 0n) {
+        value = value - (1n << BigInt(width));
+    }
+    return value;
+}
+
+// Helper: Convert signed integer to its raw unsigned representation
+function fromSigned(value, width) {
+    var sign_bit = 1n << (BigInt(width) - 1n);
+    if((value & sign_bit) !== 0n) {
+        value = value + (1n << BigInt(width));
+    }
+    return value;
+}
+
+// Helper: Convert fixed-point field value to a real number
+function fromFixedPoint(value, width, fracw, is_signed) {
+    if(is_signed) {
+        value = toSigned(value, width);
+    }
+    return Number(value) * Math.pow(2, -fracw);
+}
+
 function format_field_value(idx, value) {
-    if(RAL.get_node(CurrentID).fields[idx].disp == "D"){
-        return(value.toString());
+    var field = RAL.get_node(CurrentID).fields[idx];
+    var width = BigInt(field.msb) - BigInt(field.lsb) + 1n;
+    if(field.disp == "R") {
+        var num = fromFixedPoint(value, width, field.fracwidth, field.is_signed);
+        // Always print a decimal point for real numbers
+        return num % 1 === 0 ? num.toFixed(1) : num.toString();
+    } else if(field.disp == "D") {
+        if(field.is_signed) {
+            return toSigned(value, width).toString();
+        } else {
+            return value.toString();
+        }
     } else {
         return("0x" + value.toString(16));
+    }
+}
+
+// parse a formatted (input) value into the raw field value
+// if out of bounds, throw a RangeError with a "clamped"
+//   property containg the closest valid field value
+function parse_field_value(idx, str) {
+    var node = RAL.get_node(CurrentID);
+    var disp = node.fields[idx].disp;
+    var width = BigInt(node.fields[idx].msb) - BigInt(node.fields[idx].lsb) + 1n;
+    var is_signed = node.fields[idx].is_signed;
+
+    var value;
+    if(disp === "R") {
+        // Fixed-point: parse as real, convert to (signed) integer
+        var fracw = node.fields[idx].fracwidth;
+        var realval = Number(str);
+        if(isNaN(realval)) throw new SyntaxError("Invalid real number");
+        value = BigInt(Math.round(realval * Math.pow(2, fracw)));
+    } else {
+        // Parse as integer
+        value = BigInt(str);
+    }
+
+    // range checks
+    if(is_signed && (disp === "R" || disp === "D")) {
+        // check signed integer
+        var min = -(1n << (width - 1n));
+        var max = (1n << (width - 1n)) - 1n;
+
+        if(value < min || value > max) {
+            const err = new RangeError("Input out of bounds");
+            clamped = value < min ? min : (value > max ? max : value);
+            err.clamped = fromSigned(clamped, width);
+            throw err;
+        }
+
+        return fromSigned(value, width);
+    } else {
+        // check unsigned integer
+        var min = 0n;
+        var max = (1n << width) - 1n;
+
+        if(value < min || value > max) {
+            const err = new RangeError("Input out of bounds");
+            err.clamped = value < min ? min : (value > max ? max : value);
+            throw err;
+        }
+
+        return value;
     }
 }
 
@@ -140,10 +235,13 @@ function onRadixSwitch(el){
     var idx = RAL.lookup_field_idx(el.dataset.name);
     var node = RAL.get_node(CurrentID);
     var d = node.fields[idx].disp;
+    var field = node.fields[idx];
     if(d == "H") {
         d = "D";
-    } else if((d == "D") && ("encode" in node.fields[idx])) {
+    } else if(d == "D" && ("encode" in field)) {
         d = "E";
+    } else if((d == "D" || d == "E") && ("fracwidth" in field)) {
+        d = "R";
     } else {
         d = "H";
     }
@@ -165,22 +263,19 @@ function onDecodedFieldEnumChange(el) {
 function onDecodedFieldInput(el){
     var idx = RAL.lookup_field_idx(el.dataset.name);
     var node = RAL.get_node(CurrentID);
-    var msb = BigInt(node.fields[idx].msb);
-    var lsb = BigInt(node.fields[idx].lsb);
     var value;
 
-    try {
-        value = BigInt(el.value);
-    } catch(error) {
-        value = -1n;
-    }
-
-    var max_value = 1n << (msb - lsb + 1n);
-    if((value < 0) || (value >= max_value)){
-        if(!el.classList.contains("invalid")) el.classList.add("invalid");
-        return;
-    }
     el.classList.remove("invalid");
+    try {
+        value = parse_field_value(idx, el.value);
+    } catch(error) {
+        if(!el.classList.contains("invalid")) el.classList.add("invalid");
+        if(error instanceof RangeError) {
+            value = error.clamped;
+        } else {
+            return;
+        }
+    }
 
     if("encode" in node.fields[idx]) {
         var el2 = document.getElementById("_FieldValueEnumTester" + node.fields[idx].name);

--- a/src/peakrdl_html/templates/reg_base.html
+++ b/src/peakrdl_html/templates/reg_base.html
@@ -80,6 +80,11 @@
             {% endfor %}
             </select>
             {%- endif %}
+            {%- if field.get_property('is_signed') or field.get_property('fracwidth') != None %}
+            <div id="_FieldValueDisplay{{field.inst.inst_name}}" class="field-value-display" style="font-size:smaller;color:#808080;margin-top:6px;">
+                <!-- Value will be filled by JS -->
+            </div>
+            {%- endif %}
         </td>
         <td>{{(field.get_html_name() or "-")|safe}}</td>
         <td>

--- a/src/peakrdl_html/udps/__init__.py
+++ b/src/peakrdl_html/udps/__init__.py
@@ -1,0 +1,8 @@
+from .fixedpoint import IntWidth, FracWidth
+from .signed import IsSigned
+
+ALL_UDPS = [
+    IntWidth,
+    FracWidth,
+    IsSigned,
+]

--- a/src/peakrdl_html/udps/fixedpoint.py
+++ b/src/peakrdl_html/udps/fixedpoint.py
@@ -1,0 +1,73 @@
+from typing import Any
+
+from systemrdl.component import Field
+from systemrdl.node import Node, FieldNode
+from systemrdl.udp import UDPDefinition
+
+
+class _FixedpointWidth(UDPDefinition):
+    valid_components = {Field}
+    valid_type = int
+
+    def validate(self, node: "Node", value: Any) -> None:
+        assert isinstance(node, FieldNode)
+
+        intwidth = node.get_property("intwidth")
+        fracwidth = node.get_property("fracwidth")
+        assert intwidth is not None
+        assert fracwidth is not None
+        prop_ref = node.inst.property_src_ref.get(self.name)
+
+        # incompatible with "counter" fields
+        if node.get_property("counter"):
+            self.msg.error(
+                "Fixed-point representations are not supported for counter fields.",
+                prop_ref
+            )
+
+        # incompatible with "encode" fields
+        if node.get_property("encode") is not None:
+            self.msg.error(
+                "Fixed-point representations are not supported for fields encoded as an enum.",
+                prop_ref
+            )
+
+        # ensure node width = fracwidth + intwidth
+        if intwidth + fracwidth != node.width:
+            self.msg.error(
+                f"Number of integer bits ({intwidth}) plus number of fractional bits ({fracwidth})"
+                f" must be equal to the width of the component ({node.width}).",
+                prop_ref
+            )
+
+
+class IntWidth(_FixedpointWidth):
+    name = "intwidth"
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        """
+        If 'fracwidth' is defined, 'intwidth' is inferred from the node width.
+        """
+        assert isinstance(node, FieldNode)
+        fracwidth = node.get_property("fracwidth", default=None)
+        if fracwidth is not None:
+            return node.width - fracwidth
+        else:
+            # not a fixed-point number
+            return None
+
+
+class FracWidth(_FixedpointWidth):
+    name = "fracwidth"
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        """
+        If 'intwidth' is defined, 'fracwidth' is inferred from the node width.
+        """
+        assert isinstance(node, FieldNode)
+        intwidth = node.get_property("intwidth", default=None)
+        if intwidth is not None:
+            return node.width - intwidth
+        else:
+            # not a fixed-point number
+            return None

--- a/src/peakrdl_html/udps/signed.py
+++ b/src/peakrdl_html/udps/signed.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from systemrdl.component import Field
+from systemrdl.node import Node
+from systemrdl.udp import UDPDefinition
+
+
+class IsSigned(UDPDefinition):
+    name = "is_signed"
+    valid_components = {Field}
+    valid_type = bool
+    default_assignment = True
+
+    def validate(self, node: "Node", value: Any) -> None:
+        # "counter" fields can not be signed
+        if value and node.get_property("counter"):
+            self.msg.error(
+                "The property is_signed=true is not supported for counter fields.",
+                node.inst.property_src_ref["is_signed"]
+            )
+
+        # incompatible with "encode" fields
+        if value and node.get_property("encode") is not None:
+            self.msg.error(
+                "The property is_signed=true is not supported for fields encoded as an enum.",
+                node.inst.property_src_ref["is_signed"]
+            )
+
+    def get_unassigned_default(self, node: "Node") -> Any:
+        """
+        Unsigned by default if not specified.
+        """
+        return False


### PR DESCRIPTION
# Description of change

Add support for the `is_signed`, `intwidth`, and `fracwidth` properties as discussed in [SystemRDL/#188](https://github.com/orgs/SystemRDL/discussions/188).

![Example interactive fixedpoint/signed fields](https://github.com/user-attachments/assets/53b50b2d-38b6-47ba-8341-eecc6df2d138)

This is an initial implementation. I don't claim that all the edge cases are handled or that the output looks great. I also don't know any javascript so Copilot helped out quite a bit.

## List of changes:
- Added is_signed, fracwidth, and intwidth UDPs (implementation copied from PeakRDL-regblock)
- Added "R" (Real) radix for fixed-point fields
- The "D" radix field values are parsed/displayed as signed for signed fields
- The "D" radix is the default radix for signed fields
- The "R" radix is the default radix for fixed-point fields
- Out-of-bounds parsed field values for all radices are clamped to the nearest valid field value for the register value
  - This behavior makes sense for numeric fields, but may not be what you want for everything
- Added field value display below the entry box for signed/fixedpoint fields

## TODO (but need feedback/discussion before implementing):
- [ ] Find an appealing way to include signed/fixedpoint information in the table of fields. Where's the most appropriate place?
- [ ] Documentation. Likely all in the turbo encabulator example regfile?
- [ ] Discuss if the new saturation behavior is appropriate for all fields
- [ ] Test more edge cases

Basically I'm looking for feedback to make sure this is a good approach before polishing it all up. I could also use some direction on the aesthetic choices (does the current implementation look OK? How can we add more information to the table without cluttering it up?).